### PR TITLE
[refactor] Add typing speed function in search stimulus controller to…

### DIFF
--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -4,7 +4,19 @@ import { Controller } from "@hotwired/stimulus"
 export default class extends Controller {
   static targets = [ "form", "ipInput", "queryInput", "list", "emptySearch" ]
   connect() {
-    this.handleInput = this.debounce(this.handleInput.bind(this), 1000);
+    this.averageSpeed = 2500
+    this.handleInput = this.debounce(this.handleInput.bind(this), this.averageSpeed);
+  }
+  
+  typing_speed() {
+    this.speed = 2500
+    this.counter = 1
+    const startTime = new Date().getTime();
+    const endTime = new Date().getTime();
+    const timeElapsed = endTime - startTime;
+    this.speed += timeElapsed
+    this.counter += 1;
+    this.averageSpeed = this.speed / this.counter;
   }
 
   debounce(func, wait) {
@@ -19,6 +31,9 @@ export default class extends Controller {
   }
 
   handleInput(event) {
+    // calculate how fast the user types
+    this.typing_speed();
+    
     const url = this.formTarget.action;
 
     const options = {
@@ -32,7 +47,6 @@ export default class extends Controller {
       .then(response => response.json())
       .then((data) => {
         if (data.inserted_item) {
-          this.emptySearch.innerText = "Search Results";
           this.listTarget.insertAdjacentHTML("beforeend", data.inserted_item);
         }
         this.formTarget.outerHTML = data.form;


### PR DESCRIPTION
in `javascript/controlleres/search_controller.js`: 

Added a typing_speed function to calculate approximately how fast the user types and then use this typing speed to debounce the real time search functionality. 

